### PR TITLE
#163754575 Integrate login functionality to the login form

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/src/js/components/container/auth/index.jsx
+++ b/src/js/components/container/auth/index.jsx
@@ -56,6 +56,7 @@ class Authentication extends Component {
     componentWillReceiveProps(nextProps) {
         const { auth } = nextProps;
         const {status, message} = auth;
+        const { endpoint } = this.props.match.params;
         if (!!message) {
             this.snack.message = message;
             this.snack.open = true;
@@ -65,13 +66,17 @@ class Authentication extends Component {
             this.snack.open = false;
         }
 
-        if (status==='success') {
-            // const { history } = this.props;
-            this.setState({ ...this.initialState });
-            // history.push('/login');
-            // this.props.history.push('/login');
+        if ((status==='success')) {
+            endpoint === 'login'
+                ? this.redirect('home')
+                : this.redirect('login');
         }
     }
+
+    redirect = (endpoint) => {
+        this.setState({ ...this.initialState });
+        window.location.assign(endpoint);
+    };
 
     renderInputFields = (
         form,
@@ -97,15 +102,13 @@ class Authentication extends Component {
 
     handleSignUp = (event) => {
         event.preventDefault();
-        const { dispatch } = this.props;
+        const { dispatch, match } = this.props;
         if(!this.formHasError()) {
             const { username, email, contact, user_type, password } = this.state;
             const signupdata = { username, email, contact, user_type, password };
-            this.props.match.params.endpoint === 'admin'
+            match.params.endpoint === 'admin'
                 ? signupdata.user_type = 'admin'
                 : null;
-
-            console.log(signupdata);
             dispatch(authAction(signupdata, API.SIGN_UP_URL));
             this.setState({loader: { loading: true}})
         }
@@ -113,6 +116,11 @@ class Authentication extends Component {
 
     handleLogin = (event) => {
         event.preventDefault();
+        const { dispatch } = this.props;
+        const { username, password } = this.state;
+        const loginData = {username, password};
+        dispatch(authAction(loginData, API.LOGIN_URL));
+        this.setState({loader: { loading: true}})
     };
 
     onChange = name => (event) => {
@@ -145,10 +153,10 @@ class Authentication extends Component {
     };
 
     render() {
-        const { location } = this.props;
+        const { endpoint } = this.props.match.params;
         const { open, message, variant } = this.snack;
         const { loader } = this.state;
-        const formCustom = this.props.match.params.endpoint === 'login'
+        const formCustom = endpoint === 'login'
             ? {
                 formLabel: 'Login',
                 authButton: 'Login',
@@ -156,7 +164,7 @@ class Authentication extends Component {
                 linkWord: 'Do not have an account? Sign-up.',
                 onSubmit: this.handleLogin,
             }
-            : this.props.match.params.endpoint === "admin"
+            : endpoint === "admin"
                 ? {
                 formLabel: 'Admin Sign-up',
                 authButton: 'Register',

--- a/src/js/components/container/auth/tests/auth.test.jsx
+++ b/src/js/components/container/auth/tests/auth.test.jsx
@@ -20,6 +20,11 @@ const userData = {
     password: '1qaz2wsx'
 };
 
+const loginData = {
+    username: 'Arnold',
+    password: '1qaz2wsx'
+};
+
 describe('Auth container', () => {
     beforeEach(() => {
         store = mockStore({
@@ -27,21 +32,20 @@ describe('Auth container', () => {
                 data: {}
             }
         });
-        // window.history.pushState({}, 'auth form', '/signup');
         wrapper = shallow(<AuthenticationTest {...props} dispatch={jest.fn} />)
     });
 
     it('renders auth form without crashing', () => {
-        console.log(wrapper.debug);
         expect(wrapper).toHaveLength(1);
         wrapper.setProps({ auth: {
             status: 'success',
                 message: "Successfully registered",
                 data: {
-                contact: "0706180670",
+                    contact: "0706180670",
                     email: "kabo@mail.com",
                     user_name: "Kabody",
-                    user_type: "client"}
+                    user_type: "client"
+                }
         }});
         wrapper.setProps({ auth: {
                 status: 'fail',
@@ -81,13 +85,20 @@ describe('Auth container', () => {
     });
 
     it('should sign-up an admin user', () => {
-        const prop = {
+        const props = {
             match: {params: {endpoint: 'admin'}}
         };
-       const wrap = shallow(<AuthenticationTest {...prop} dispatch={jest.fn} />);
+       const wrap = shallow(<AuthenticationTest {...props} dispatch={jest.fn} />);
         wrap.setState(userData);
         wrap.instance().handleSignUp({ preventDefault: jest.fn });
         wrap.instance().handleSignUp({ preventDefault: jest.fn });
+    });
+
+    it('should login a user', () => {
+        const wrap = shallow(<AuthenticationTest {...props} dispatch={jest.fn} />);
+        wrap.setState(loginData);
+        wrap.instance().handleLogin({ preventDefault: jest.fn });
+        wrap.instance().handleLogin({ preventDefault: jest.fn });
     });
 
     it('mount the component ', () => {

--- a/src/js/redux/actions/auth/tests/auth.test.jsx
+++ b/src/js/redux/actions/auth/tests/auth.test.jsx
@@ -46,21 +46,33 @@ describe('Auth actions', () => {
             }
         });
 
-        const expectedActions = [{ payload: { message: "Successfully registered",status: "success", data: {} }, type: 'SIGN_UP' }];
         store.dispatch(authAction(userData, API.SIGN_UP_URL)).then(() => {
-            expect(store.getActions()).toEqual(expectedActions);
+            expect(store.getActions()).toEqual(
+                [{
+                    payload: { message: "Successfully registered",status: "success", data: {} },
+                    type: 'SIGN_UP'
+                }]
+            );
         });
     });
 
     it('failed sign-up with missing data', () => {
         moxios.stubRequest(API.SIGN_UP_URL, {
-            status: 400
+            status: 400,
+            response: {
+                message: "unsuccessful",
+                status: "fail",
+                data: false
+            }
         });
 
-        const expectedActions = [{ payload: {}, type: 'SIGN_UP' }];
-
         store.dispatch(authAction(userDataIncomplete, API.SIGN_UP_URL)).then(() => {
-            expect(store.getActions()).toEqual(expectedActions);
+            expect(store.getActions()).toEqual(
+                [{
+                    payload: { message: "unsuccessful",status: "fail", data: false },
+                    type: 'SIGN_UP'
+                }]
+            );
         });
     });
 

--- a/src/js/redux/reducers/auth/index.js
+++ b/src/js/redux/reducers/auth/index.js
@@ -25,7 +25,7 @@ const authReducer = (state = initialState, action) => {
         default:
             return { ...state, user: data };
     }
-}
+};
 
 export default authReducer
 

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -6,10 +6,8 @@ import Authentication from "../js/components/container/auth/index.jsx";
 const Routes = () => (
     <Router>
         <Switch>
-            <Route component={App} path="/" exact />
+            <Route component={App} path="/home" exact />
             <Route component={Authentication} path="/:endpoint" exact />
-            {/*<Route component={Authentication} path="/:admin" exact />*/}
-            {/*<Route component={Authentication} path="/:login" exact />*/}
         </Switch>
     </Router>
 );


### PR DESCRIPTION
#### What this PR does?
- add redirection to the home page after successful login
- display notifications on unsuccessful login
- write tests
#### Description of Task to be completed?
- A user should be able to access a well styled up form for login.
- A user should be able to view notification on unsuccessful login.
- Users should be able to Login using a login form through the login route.
#### How should this be manually tested?
After cloning the repo, cd into it and follow the steps 
* In terminal, type `git checkout ft-login-form-163754575` to switch to my branch.
* Then type `npm install` to install all the project dependencies in package.json **Note** ensure that you have nodejs installed on your computer. 
* Finally, type `npm start` to run the project server and then open your browser and type `http://localhost:3000/login` to access the Login page.
#### What are the relevant pivotal tracker stories?
[#163754575 https://www.pivotaltracker.com/story/show/163754575]
#### Screenshots
![image](https://user-images.githubusercontent.com/25249904/52516846-e1d7f100-2c42-11e9-88ac-fb9c8faddc40.png)
